### PR TITLE
implement PKCE flow but keep backwards compatibility

### DIFF
--- a/BMXCore/APIClient.swift
+++ b/BMXCore/APIClient.swift
@@ -254,18 +254,20 @@ public class APIClient {
     
     class func refreshTokens(completion: @escaping (Result<BMXAuthProvider, Error>) -> Void) {
         let urlString = BMXCoreKit.shared.environment.backendEnvironment.accountURL + "/oauth/token"
-        guard let refreshToken = BMXCoreKit.shared.authProvider.refreshToken, let clientID = BMXCoreKit.shared.authProvider.clientID,
-        let secret = BMXCoreKit.shared.authProvider.secret else {
-            completion(.failure(ServiceError.unableToCreateRequest(message: "refreshToken, clientID or secret is missing")))
+        guard let refreshToken = BMXCoreKit.shared.authProvider.refreshToken,
+              let clientID = BMXCoreKit.shared.authProvider.clientID else {
+            completion(.failure(ServiceError.unableToCreateRequest(message: "refreshToken or clientID is missing")))
             return
         }
 
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "refresh_token": refreshToken,
             "client_id": clientID,
-            "grant_type": "refresh_token",
-            "client_secret": secret
+            "grant_type": "refresh_token"
         ]
+        if let secret = BMXCoreKit.shared.authProvider.secret, !secret.isEmpty {
+            parameters["client_secret"] = secret
+        }
 
         BMXCoreKit.shared.log(message: "Requesting new Access Token")
         AuthSessionManager.shared.sessionManager.request(urlString, method: .post, parameters: parameters, encoding: JSONEncoding.default)

--- a/BMXCore/Auth/BMXAuthProvider.swift
+++ b/BMXCore/Auth/BMXAuthProvider.swift
@@ -55,6 +55,17 @@ public final class BMXAuthProvider {
         setUserTokens(accessToken: accessToken, refreshToken: refreshToken)
     }
 
+    public init(clientID: String) {
+        self.storage = TempStorage()
+        setSession(secret: nil, clientID: clientID)
+    }
+
+    public init(clientID: String, accessToken: String, refreshToken: String) {
+        self.storage = TempStorage()
+        setSession(secret: nil, clientID: clientID)
+        setUserTokens(accessToken: accessToken, refreshToken: refreshToken)
+    }
+
     init(storage: KeyValueStorage) {
         self.storage = storage
     }

--- a/BMXCore/BMXCoreKit.swift
+++ b/BMXCore/BMXCoreKit.swift
@@ -208,8 +208,7 @@ public class BMXCoreKit {
             responseType: "code"
         )
 
-        oauth?.allowMissingStateCheck = true
-
+        let state = generateState(withLength: 20)
         let parameters: [String: String] = promptLogin ? ["prompt": "login"] : [:]
         let handler = SafariURLHandler(viewController: viewController, oauthSwift: oauth!)
         handler.delegate = authorizationWebViewDelegate
@@ -235,7 +234,7 @@ public class BMXCoreKit {
             oauth?.authorize(
                 withCallbackURL: callbackURL,
                 scope: "openid+profile",
-                state: "",
+                state: state,
                 codeChallenge: codeChallenge,
                 codeChallengeMethod: "S256",
                 codeVerifier: codeVerifier,
@@ -243,7 +242,7 @@ public class BMXCoreKit {
                 completionHandler: completion
             )
         } else {
-            oauth?.authorize(withCallbackURL: callbackURL, scope: "openid+profile", state: "", parameters: parameters, completionHandler: completion)
+            oauth?.authorize(withCallbackURL: callbackURL, scope: "openid+profile", state: state, parameters: parameters, completionHandler: completion)
         }
 
         return promise

--- a/BMXCore/BMXCoreKit.swift
+++ b/BMXCore/BMXCoreKit.swift
@@ -195,33 +195,55 @@ public class BMXCoreKit {
 
     private func authorize(with callbackURL: URL, viewController: UIViewController, promptLogin: Bool) -> Future<TokensModel> {
         let promise = Promise<TokensModel>()
-        guard let consumerKey = authProvider.clientID, let consumerSecret = authProvider.secret else {
-            promise.reject(with: ServiceError.unableToCreateRequest(message: "clientID or secret is missing"))
+        guard let consumerKey = authProvider.clientID else {
+            promise.reject(with: ServiceError.unableToCreateRequest(message: "clientID is missing"))
             return promise
         }
 
         oauth = OAuth2Swift(
             consumerKey: consumerKey,
-            consumerSecret: consumerSecret,
+            consumerSecret: authProvider.secret ?? "",
             authorizeUrl: environment.backendEnvironment.oauthAuthorize,
             accessTokenUrl: environment.backendEnvironment.oauthToken,
             responseType: "code"
         )
 
         oauth?.allowMissingStateCheck = true
-        
+
         let parameters: [String: String] = promptLogin ? ["prompt": "login"] : [:]
-        let authorizeURLHandler = SafariURLHandler(viewController: viewController, oauthSwift: oauth!)
-        authorizeURLHandler.delegate = authorizationWebViewDelegate
-        oauth?.authorizeURLHandler = authorizeURLHandler
-        
-        oauth?.authorize(withCallbackURL: callbackURL, scope: "openid+profile", state:"", parameters: parameters) { result in
+        let handler = SafariURLHandler(viewController: viewController, oauthSwift: oauth!)
+        handler.delegate = authorizationWebViewDelegate
+        oauth?.authorizeURLHandler = handler
+
+        let usePKCE = authProvider.secret == nil || authProvider.secret?.isEmpty == true
+
+        let completion: OAuthSwift.TokenCompletionHandler = { result in
             switch result {
             case .success(let (credential, _, _)):
                 promise.resolve(with: TokensModel(access_token: credential.oauthToken, refresh_token: credential.oauthRefreshToken))
             case .failure(let error):
                 promise.reject(with: error)
             }
+        }
+
+        if usePKCE {
+            guard let codeVerifier = generateCodeVerifier(),
+                  let codeChallenge = generateCodeChallenge(codeVerifier: codeVerifier) else {
+                promise.reject(with: ServiceError.unableToCreateRequest(message: "Failed to generate PKCE parameters"))
+                return promise
+            }
+            oauth?.authorize(
+                withCallbackURL: callbackURL,
+                scope: "openid+profile",
+                state: "",
+                codeChallenge: codeChallenge,
+                codeChallengeMethod: "S256",
+                codeVerifier: codeVerifier,
+                parameters: parameters,
+                completionHandler: completion
+            )
+        } else {
+            oauth?.authorize(withCallbackURL: callbackURL, scope: "openid+profile", state: "", parameters: parameters, completionHandler: completion)
         }
 
         return promise


### PR DESCRIPTION
 Add PKCE support for public OAuth clients

  Adds PKCE (RFC 7636) as a first-class authorization flow so mobile apps can authenticate without embedding a client_secret in the binary. Partners who already pass a secret
   continue to work with zero changes.

  Changes

  BMXAuthProvider — two new public initializers:
  - init(clientID:) — for PKCE-only clients
  - init(clientID:accessToken:refreshToken:) — for bring-your-own-tokens with PKCE refresh

  BMXCoreKit — authorize(with:viewController:promptLogin:):
  - No longer requires secret to be set; only clientID is mandatory
  - When secret is nil/empty, uses OAuthSwift's PKCE authorize overload with code_challenge (S256) and code_verifier; omits client_secret from the token exchange
  automatically
  - When secret is present, falls back to the existing legacy flow unchanged

  APIClient — refreshTokens(completion:):
  - Guard no longer fails when secret is absent
  - client_secret is included in the refresh request body only when a non-empty secret exists

  Backward compatibility

  Existing integrations passing a secret are unaffected — they take the same code path as before. No new dependencies; OAuthSwift 2.2.0 (already pinned) provides the PKCE
  helpers and overload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication can be configured with only a client ID (client secret optional).
  * New auth initializers let you create sessions without a client secret and optionally prepopulate tokens.
  * OAuth2 flow now supports PKCE when a client secret is not provided.
  * Token refreshes no longer require a client secret; the secret is included only when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->