### PR TITLE
Add support of CocoaPods with latest SDK

### DIFF
--- a/BMXCall.podspec
+++ b/BMXCall.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.summary      = 'A Swift framework to implement ButterflyMX SDK'
   spec.homepage     = "https://github.com/runslikebutter/butterflymx-sdk-ios"
 
-  spec.license      = "Apache-2.0 license"
+  spec.license      = "Apache-2.0"
   spec.author       = { "ButterflyMX" => "admin@butterflymx.com" }
   spec.source       = { :git => "https://github.com/runslikebutter/butterflymx-sdk-ios.git", :tag => 'v' + spec.version.to_s }
 

--- a/BMXCall.podspec
+++ b/BMXCall.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |spec|
+  spec.name = 'BMXCall'
+  spec.version = '2.3.8'
+  spec.swift_versions = ['5']
+
+  spec.cocoapods_version = '>= 1.13.0'
+  spec.ios.deployment_target = '14.0'
+
+  spec.summary      = 'A Swift framework to implement ButterflyMX SDK'
+  spec.homepage     = "https://github.com/runslikebutter/butterflymx-sdk-ios"
+
+  spec.license      = "Apache-2.0 license"
+  spec.author       = { "ButterflyMX" => "admin@butterflymx.com" }
+  spec.source       = { :git => "https://github.com/runslikebutter/butterflymx-sdk-ios.git", :tag => 'v' + spec.version.to_s }
+
+  spec.source_files  = "BMXCall/**/*.swift"
+
+  spec.dependency 'BMXCore', '~> 2.3.8'
+  spec.dependency 'TwilioVideo', '~> 5.8.1'
+
+  spec.resource_bundles = {'BMXCall' => ['BMXCall/PrivacyInfo.xcprivacy']}
+end

--- a/BMXCall.podspec
+++ b/BMXCall.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'BMXCall'
-  spec.version = '2.3.8'
+  spec.version = '2.3.9'
   spec.swift_versions = ['5']
 
   spec.cocoapods_version = '>= 1.13.0'

--- a/BMXCore.podspec
+++ b/BMXCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "BMXCore"
-  spec.version      = "2.3.8"
+  spec.version      = "2.3.9"
   spec.swift_versions = ['5']
 
   spec.cocoapods_version = '>= 1.13.0'

--- a/BMXCore.podspec
+++ b/BMXCore.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |spec|
+
+  spec.name         = "BMXCore"
+  spec.version      = "2.3.8"
+  spec.swift_versions = ['5']
+
+  spec.cocoapods_version = '>= 1.13.0'
+  spec.ios.deployment_target = '14.0'
+
+  spec.summary      = 'A Swift framework to implement ButterflyMX SDK'
+  spec.homepage     = "https://github.com/runslikebutter/butterflymx-sdk-ios"
+
+  spec.license      = "Apache-2.0 license"
+  spec.author       = { "ButterflyMX" => "admin@butterflymx.com" }
+  spec.source       = { :git => "https://github.com/runslikebutter/butterflymx-sdk-ios.git", :tag => 'v' + spec.version.to_s }
+
+  spec.source_files  = "BMXCore/**/*.swift"
+
+  spec.dependency 'Alamofire', '>= 5.6.1', '< 5.10.0'
+  spec.dependency 'Japx/Alamofire', '~> 4.0'
+  spec.dependency 'OAuthSwift', '~> 2.2'
+
+  spec.resource_bundles = {'BMXCore' => ['BMXCore/PrivacyInfo.xcprivacy']}
+
+end

--- a/BMXCore.podspec
+++ b/BMXCore.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.summary      = 'A Swift framework to implement ButterflyMX SDK'
   spec.homepage     = "https://github.com/runslikebutter/butterflymx-sdk-ios"
 
-  spec.license      = "Apache-2.0 license"
+  spec.license      = "Apache-2.0"
   spec.author       = { "ButterflyMX" => "admin@butterflymx.com" }
   spec.source       = { :git => "https://github.com/runslikebutter/butterflymx-sdk-ios.git", :tag => 'v' + spec.version.to_s }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CocoaPods package specifications for BMXCall and BMXCore (v2.3.8) to enable distribution via CocoaPods.
  * Both frameworks require iOS 14.0 or later and Swift 5+.
  * Third-party dependencies are declared for proper integration.
  * Privacy compliance information included in bundled resources for both frameworks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runslikebutter/butterflymx-sdk-ios/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->